### PR TITLE
fix: fallback to 啟字 if no documents are found in `JudicialLawsuitPage`

### DIFF
--- a/src/pages/documents/judicial/JudicialLawsuitPage.vue
+++ b/src/pages/documents/judicial/JudicialLawsuitPage.vue
@@ -70,7 +70,9 @@ import { useCollection } from 'vuefire';
 import orderBy from 'lodash/orderBy';
 import { useRouter } from 'vue-router';
 import { useMeta } from 'quasar';
+import { useDocumentStore } from 'stores/document.ts';
 
+const store = useDocumentStore();
 const step = ref(0);
 const stepper = ref();
 const findBy = ref<null | 'select' | 'id'>(null);
@@ -128,15 +130,24 @@ function chooseFindBy(type: 'select' | 'id') {
   step.value = type === 'select' ? 1 : 3;
 }
 
-function next() {
+async function next() {
   switch (step.value) {
     case 1:
       reignInput.value.validate();
       if (reignInput.value.hasError) return;
       loadOptions();
       break;
-    case 3:
-      void router.push(`/document/judicial/lawsuit/${idPrefix.value}第${idNumber.value}號`); //TODO check if doc exists before redirecting
+    case 3: {
+      const primaryId = `${idPrefix.value}第${idNumber.value}號`;
+      const docs = await store.loadLawsuit(primaryId);
+      if (docs && docs.length > 0) {
+        void router.push(`/document/judicial/lawsuit/${primaryId}`);
+      } else {
+        const prefix = courtType.value === '一般法庭' ? '政' : '憲';
+        void router.push(`/document/judicial/lawsuit/${prefix}啟字第${idNumber.value}號`);
+      }
+      break;
+    }
   }
   stepper.value.next();
 }


### PR DESCRIPTION
This pull request updates the navigation logic for the judicial lawsuit document page to check for the existence of a document before redirecting, and introduces the use of a centralized document store. The most important changes are:

**Document retrieval and navigation logic:**
* The `next` function now checks if a lawsuit document exists by calling `store.loadLawsuit(primaryId)` before redirecting. If the document is found, it navigates to the existing document; otherwise, it constructs a fallback document ID based on the court type and redirects accordingly.

**State management:**
* The `useDocumentStore` store is imported and initialized, centralizing document retrieval logic and improving maintainability.